### PR TITLE
Add support for ref prop in PhoneField component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow prop `ref` to be passed to `PhoneField`.
+
 ## [0.1.0] - 2020-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow prop `ref` to be passed to `PhoneField`.
 
+### Fixed
+
+- Phone number not rendered when rule don't have a mask.
+
 ## [0.1.0] - 2020-03-19
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,7 +79,7 @@ a placeholder.
 
 ## Components
 
-### PhoneField component
+### PhoneField
 
 Responsible for rendering the listbox with the text field and formatting and validating the phone number.
 
@@ -114,7 +114,7 @@ or by changing the country from the listbox.
 The default country to show in the listbox. Used only when the phone number passed in `value`
 doesn't have a country calling code or if we don't have a `value` at all.
 
-### PhoneContext.PhoneContextProvider component
+### PhoneContext.PhoneContextProvider
 
 The wrapper component for the phone number that provides the rules definitions.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,11 +23,11 @@ To use this app, you first need to add it in your `manifest.json` file, like so
 
 Then, you can import the phone context and field components and use it inside your forms:
 
-```tsx
+```jsx
 import React from 'react'
 import { PhoneField, PhoneContext, rules } from 'vtex.phone-field'
 
-const Form: React.FC = () => {
+const Form = () => {
   const [phone, setPhone] = React.useState('+15554567038')
 
   const handlePhoneChange = React.useCallback(({ value, isValid }) => {
@@ -79,7 +79,7 @@ a placeholder.
 
 ## Components
 
-### `<PhoneField />`
+### PhoneField component
 
 Responsible for rendering the listbox with the text field and formatting and validating the phone number.
 
@@ -114,7 +114,7 @@ or by changing the country from the listbox.
 The default country to show in the listbox. Used only when the phone number passed in `value`
 doesn't have a country calling code or if we don't have a `value` at all.
 
-### `<PhoneContext.PhoneContextProvider />`
+### PhoneContext.PhoneContextProvider component
 
 The wrapper component for the phone number that provides the rules definitions.
 

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -133,7 +133,11 @@ const PhoneField = React.forwardRef<HTMLInputElement, Props>(
         <Input
           {...props}
           inputMode="numeric"
-          value={msk(phoneData.phoneValue, countryRule.mask ?? '')}
+          value={
+            countryRule.mask
+              ? msk(phoneData.phoneValue, countryRule.mask)
+              : phoneData.phoneValue
+          }
           onChange={handleChange}
           ref={(node: HTMLInputElement) => {
             if (ref) {

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -140,11 +140,12 @@ const PhoneField = React.forwardRef<HTMLInputElement, Props>(
               if (typeof ref === 'function') {
                 ref(node)
               } else {
-                // @ts-ignore: not read-only
+                // @ts-ignore: React TS types says this is read-only, but
+                // it its possible to mutate this value
                 ref.current = node
               }
             }
-            // @ts-ignore: not read-only
+            // @ts-ignore: same as above
             inputRef.current = node
           }}
           prefix={

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -35,12 +35,21 @@ interface PhoneData {
   isValid: boolean
 }
 
-interface Props {
+interface Props
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'onChange' | 'value'
+  > {
   onChange?: (data: PhoneData) => void
   value?: string
   defaultCountry?: string
-  // Input props which don't have a TS definition
-  [key: string]: any
+  // Input's props
+  label?: string | React.ReactElement
+  error?: boolean
+  errorMessage?: boolean
+  helpText?: React.ReactNode
+  suffix?: React.ReactNode
+  isLoadingButton?: boolean
 }
 
 const renderCountryFlagWithCode = ({

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -63,12 +63,10 @@ const renderCountryFlagWithCode = ({
 
 const unmaskPhone = (phone: string) => phone.replace(/\D/g, '')
 
-const PhoneField: React.FC<Props> = ({
-  onChange = () => {},
-  value = '',
-  defaultCountry = 'BRA',
-  ...props
-}) => {
+const PhoneField: React.ForwardRefRenderFunction<HTMLInputElement, Props> = (
+  { onChange = () => {}, value = '', defaultCountry = 'BRA', ...props },
+  ref
+) => {
   const { rules } = usePhoneContext()
   const inputRef = useRef<HTMLInputElement>()
 
@@ -134,7 +132,17 @@ const PhoneField: React.FC<Props> = ({
         inputMode="numeric"
         value={msk(phoneData.phoneValue, countryRule.mask ?? '')}
         onChange={handleChange}
-        ref={inputRef}
+        ref={(node: HTMLInputElement) => {
+          if (typeof ref === 'function') {
+            ref(node)
+          } else if (ref != null) {
+            // @ts-ignore: React TS types says this is read-only, but
+            // it its possible to mutate this value
+            ref.current = node
+          }
+
+          inputRef.current = node
+        }}
         prefix={
           <ListboxInput
             className="h-100 flex-auto"

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -63,129 +63,134 @@ const renderCountryFlagWithCode = ({
 
 const unmaskPhone = (phone: string) => phone.replace(/\D/g, '')
 
-const PhoneField: React.ForwardRefRenderFunction<HTMLInputElement, Props> = (
-  { onChange = () => {}, value = '', defaultCountry = 'BRA', ...props },
-  ref
-) => {
-  const { rules } = usePhoneContext()
-  const inputRef = useRef<HTMLInputElement>()
+const PhoneField = React.forwardRef<HTMLInputElement, Props>(
+  function PhoneField(
+    { onChange = () => {}, value = '', defaultCountry = 'BRA', ...props },
+    ref
+  ) {
+    const { rules } = usePhoneContext()
+    const inputRef = useRef<HTMLInputElement>(null)
 
-  const phoneData = useMemo(() => {
-    let phoneValue = value
-    let selectedCountry = defaultCountry
+    const phoneData = useMemo(() => {
+      let phoneValue = value
+      let selectedCountry = defaultCountry
 
-    if (value.startsWith('+')) {
-      phoneValue = unmaskPhone(value.substr(1))
-      const phoneRule = rules.find(({ countryCode }) => {
-        return phoneValue.startsWith(countryCode)
-      })
+      if (value.startsWith('+')) {
+        phoneValue = unmaskPhone(value.substr(1))
+        const phoneRule = rules.find(({ countryCode }) => {
+          return phoneValue.startsWith(countryCode)
+        })
 
-      if (!phoneRule) {
-        throw new Error(`Unsupported phone number ${value}.`)
+        if (!phoneRule) {
+          throw new Error(`Unsupported phone number ${value}.`)
+        }
+
+        selectedCountry = phoneRule.countryISO
+        phoneValue = phoneValue.substr(phoneRule.countryCode.length)
+      } else {
+        phoneValue = unmaskPhone(value)
       }
 
-      selectedCountry = phoneRule.countryISO
-      phoneValue = phoneValue.substr(phoneRule.countryCode.length)
-    } else {
-      phoneValue = unmaskPhone(value)
+      return { phoneValue, selectedCountry }
+    }, [defaultCountry, rules, value])
+
+    const countryRule = useMemo(
+      () =>
+        rules.find(
+          ({ countryISO }) => countryISO === phoneData.selectedCountry
+        ),
+      [rules, phoneData.selectedCountry]
+    )!
+
+    const updatePhone = (phone: string, rule: PhoneRuleDescriptor) => {
+      const updatedValue = rule.mask ? msk.fit(phone, rule.mask) : phone
+
+      onChange({
+        value: `+${rule.countryCode}${unmaskPhone(updatedValue)}`,
+        isValid: !rule.mask || rule.mask.length === updatedValue.length,
+      })
     }
 
-    return { phoneValue, selectedCountry }
-  }, [defaultCountry, rules, value])
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = ({
+      target: { value: eventValue },
+    }) => {
+      updatePhone(eventValue, countryRule)
+    }
 
-  const countryRule = useMemo(
-    () =>
-      rules.find(({ countryISO }) => countryISO === phoneData.selectedCountry),
-    [rules, phoneData.selectedCountry]
-  )!
+    const handleCountryUpdate = (country: string) => {
+      const newRule = rules.find(({ countryISO }) => countryISO === country)!
 
-  const updatePhone = (phone: string, rule: PhoneRuleDescriptor) => {
-    const updatedValue = rule.mask ? msk.fit(phone, rule.mask) : phone
+      updatePhone(phoneData.phoneValue, newRule)
 
-    onChange({
-      value: `+${rule.countryCode}${unmaskPhone(updatedValue)}`,
-      isValid: !rule.mask || rule.mask.length === updatedValue.length,
-    })
-  }
+      // schedule focus for the next tick since the listbox
+      // is already focused by default after this event handler,
+      // and we need to override that
+      setTimeout(() => void inputRef.current?.focus(), 0)
+    }
 
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = ({
-    target: { value: eventValue },
-  }) => {
-    updatePhone(eventValue, countryRule)
-  }
-
-  const handleCountryUpdate = (country: string) => {
-    const newRule = rules.find(({ countryISO }) => countryISO === country)!
-
-    updatePhone(phoneData.phoneValue, newRule)
-
-    // schedule focus for the next tick since the listbox
-    // is already focused by default after this event handler,
-    // and we need to override that
-    setTimeout(() => void inputRef.current?.focus(), 0)
-  }
-
-  return (
-    <div className={styles.phoneField}>
-      <Input
-        {...props}
-        inputMode="numeric"
-        value={msk(phoneData.phoneValue, countryRule.mask ?? '')}
-        onChange={handleChange}
-        ref={(node: HTMLInputElement) => {
-          if (typeof ref === 'function') {
-            ref(node)
-          } else if (ref != null) {
-            // @ts-ignore: React TS types says this is read-only, but
-            // it its possible to mutate this value
-            ref.current = node
-          }
-
-          inputRef.current = node
-        }}
-        prefix={
-          <ListboxInput
-            className="h-100 flex-auto"
-            value={phoneData.selectedCountry}
-            onChange={handleCountryUpdate}
-          >
-            <ListboxButton
-              arrow={
-                <div className="c-action-primary flex items-center ml2">
-                  <ArrowDownIcon size={16} />
-                </div>
+    return (
+      <div className={styles.phoneField}>
+        <Input
+          {...props}
+          inputMode="numeric"
+          value={msk(phoneData.phoneValue, countryRule.mask ?? '')}
+          onChange={handleChange}
+          ref={(node: HTMLInputElement) => {
+            if (ref) {
+              if (typeof ref === 'function') {
+                ref(node)
+              } else {
+                // @ts-ignore: not read-only
+                ref.current = node
               }
+            }
+            // @ts-ignore: not read-only
+            inputRef.current = node
+          }}
+          prefix={
+            <ListboxInput
+              className="h-100 flex-auto"
+              value={phoneData.selectedCountry}
+              onChange={handleCountryUpdate}
             >
-              {({ label }) =>
-                renderCountryFlagWithCode({
-                  country: phoneData.selectedCountry,
-                  code: label,
-                })
-              }
-            </ListboxButton>
-            <ListboxPopover className="nl1" style={{ minWidth: 192 }}>
-              <ListboxList>
-                {rules.map(({ countryCode, countryISO }) => {
-                  return (
-                    <ListboxOption
-                      value={countryISO}
-                      label={countryCode}
-                      key={countryISO}
-                    >
-                      {renderCountryFlagWithCode({
-                        country: countryISO,
-                        code: countryCode,
-                      })}
-                    </ListboxOption>
-                  )
-                })}
-              </ListboxList>
-            </ListboxPopover>
-          </ListboxInput>
-        }
-      />
-    </div>
-  )
-}
+              <ListboxButton
+                arrow={
+                  <div className="c-action-primary flex items-center ml2">
+                    <ArrowDownIcon size={16} />
+                  </div>
+                }
+              >
+                {({ label }) =>
+                  renderCountryFlagWithCode({
+                    country: phoneData.selectedCountry,
+                    code: label,
+                  })
+                }
+              </ListboxButton>
+              <ListboxPopover className="nl1" style={{ minWidth: 192 }}>
+                <ListboxList>
+                  {rules.map(({ countryCode, countryISO }) => {
+                    return (
+                      <ListboxOption
+                        value={countryISO}
+                        label={countryCode}
+                        key={countryISO}
+                      >
+                        {renderCountryFlagWithCode({
+                          country: countryISO,
+                          code: countryCode,
+                        })}
+                      </ListboxOption>
+                    )
+                  })}
+                </ListboxList>
+              </ListboxPopover>
+            </ListboxInput>
+          }
+        />
+      </div>
+    )
+  }
+)
 
 export default PhoneField

--- a/react/__tests__/PhoneField.test.tsx
+++ b/react/__tests__/PhoneField.test.tsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, act } from '@vtex/test-tools/react'
-import React, { useState } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 
 import PhoneField from '../PhoneField'
 import defaultRules, { PhoneRuleDescriptor } from '../rules'
@@ -103,6 +103,32 @@ describe('<PhoneField />', () => {
     })
 
     expect(document.activeElement).toBe(phoneInput)
+  })
+
+  it('should be able to accept refs in phone field', () => {
+    let ref = null
+
+    const Component: React.FC = () => {
+      const inputRef = useRef<HTMLInputElement>(null)
+
+      useEffect(() => {
+        ref = inputRef.current
+      })
+
+      return (
+        <PhoneContextProvider rules={defaultRules}>
+          <PhoneField
+            label="Phone number"
+            value="+5511999998888"
+            ref={inputRef}
+          />
+        </PhoneContextProvider>
+      )
+    }
+
+    const { getByLabelText } = render(<Component />)
+
+    expect(ref).toBe(getByLabelText(/phone number/i))
   })
 
   describe('default rules', () => {

--- a/react/__tests__/PhoneField.test.tsx
+++ b/react/__tests__/PhoneField.test.tsx
@@ -131,6 +131,29 @@ describe('<PhoneField />', () => {
     expect(ref).toBe(getByLabelText(/phone number/i))
   })
 
+  it("should show phone number when rule don't have a mask", () => {
+    const rules = [
+      {
+        countryISO: 'ABC',
+        countryCode: '1',
+      },
+    ]
+
+    const Component: React.FC = () => {
+      return (
+        <PhoneContextProvider rules={rules}>
+          <PhoneField label="Phone number" value="+1123456" />
+        </PhoneContextProvider>
+      )
+    }
+
+    const { getByLabelText } = render(<Component />)
+
+    const phoneInput = getByLabelText(/phone number/i)
+
+    expect(phoneInput).toHaveValue('123456')
+  })
+
   describe('default rules', () => {
     it('should correctly render the flag from the phone number', () => {
       const Component: React.FC = () => {


### PR DESCRIPTION
#### What problem is this solving?
Updates the `PhoneField` component to forward the ref to styleguide's `Input`.

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32825/criar-componentes-de-profile-form-e-profile-preview)

##### Note to reviewers

I recommend you checking the "hide whitespace changes", so it'll be easier to review this
<img width="279" alt="image" src="https://user-images.githubusercontent.com/10223856/77180301-7d739c00-6aa8-11ea-9a59-11ea7a39d8ec.png">

#### How should this be manually tested?
[Workspace](https://lucas--checkoutio.myvtex.com/checkout/#profile)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->