### PR TITLE
Fix errorMessage type in props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prop `errorMessage` incorrectly typed in `PhoneField`.
+
 ## [0.1.1] - 2020-03-20
 
 ### Added

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -46,7 +46,7 @@ interface Props
   // Input's props
   label?: string | React.ReactElement
   error?: boolean
-  errorMessage?: boolean
+  errorMessage?: string
   helpText?: React.ReactNode
   suffix?: React.ReactNode
   isLoadingButton?: boolean


### PR DESCRIPTION
#### What problem is this solving?
Fix the type for the `errorMessage` prop, which was wrongly typed as `boolean | undefined`, instead of `string | undefined`.

I didn't create tests for this fix because theoretically this type should be available at styleguide itself, but the conversion to typescript isn't done on their side yet.

#### How should this be manually tested?
[Workspace](https://lucas--checkoutio.myvtex.com/checkout/#profile)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->