### PR TITLE
Fix input typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix Input Type
 
 ## [0.1.4] - 2020-06-15
 ### Changed

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -36,6 +36,7 @@ interface Props
   errorMessage?: string
   helpText?: React.ReactNode
   suffix?: React.ReactNode
+  size: 'small' | 'regular' | 'large'
   isLoadingButton?: boolean
 }
 

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -25,7 +25,7 @@ interface PhoneData {
 interface Props
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    'onChange' | 'value'
+    'onChange' | 'value' | 'size'
   > {
   onChange?: (data: PhoneData) => void
   value?: string

--- a/react/PhoneField.tsx
+++ b/react/PhoneField.tsx
@@ -36,7 +36,7 @@ interface Props
   errorMessage?: string
   helpText?: React.ReactNode
   suffix?: React.ReactNode
-  size: 'small' | 'regular' | 'large'
+  size?: 'small' | 'regular' | 'large'
   isLoadingButton?: boolean
 }
 


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Our styleguide Input uses `size` [property](https://styleguide.vtex.com/#/Components/Forms/Input) which has a different type from [HTLMInputElement size](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#size)

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
X | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
